### PR TITLE
Attempt to fix naming of service ports to avoid overlapping names

### DIFF
--- a/deployment/helm/templates/django-deployment.yaml
+++ b/deployment/helm/templates/django-deployment.yaml
@@ -88,7 +88,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
           ports:
-            - name: http
+            - name: http-uwsgi
               containerPort: {{ .Values.saleor.django.uwsgi.port }}
               protocol: TCP
           livenessProbe:

--- a/deployment/helm/templates/django-service.yaml
+++ b/deployment/helm/templates/django-service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.saleor.service.type }}
   ports:
     - name: http-django
-      targetPort: http
+      targetPort: http-uwsgi
       port: {{ .Values.saleor.service.port }}
       protocol: TCP
   selector:

--- a/deployment/helm/templates/nginx-deployment.yaml
+++ b/deployment/helm/templates/nginx-deployment.yaml
@@ -161,7 +161,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
           ports:
-            - name: http
+            - name: http-nginx
               containerPort: {{ .Values.saleor.nginx.containerPort }}
               protocol: TCP
           livenessProbe:

--- a/deployment/helm/templates/nginx-service.yaml
+++ b/deployment/helm/templates/nginx-service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.saleor.service.type }}
   ports:
     - name: http-nginx
-      targetPort: http
+      targetPort: http-nginx
       port: {{ .Values.saleor.service.port }}
       protocol: TCP
   selector:


### PR DESCRIPTION
***What does this commit/MR/PR do?***

- Attempt to fix naming of service ports to avoid overlapping names

***Why is this commit/MR/PR needed?***

- Might fix problem where request to static seems to go to both django
and nginx