### PR TITLE
Fix eq comparison in elasticsearch parts

### DIFF
--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -223,8 +223,8 @@ env:
 {{- if eq .Values.elasticsearch.enabled true }}
   - name: ELASTICSEARCH_URL
     value: "http://$(ELASTICSEARCH_HOST):$(ELASTICSEARCH_PORT)"
-{{- else if .Values.saleor.django.externalServices.elasticsearch.enabled true }}
-{{- if .Values.saleor.django.externalServices.elasticsearch.tls true }}
+{{- else if eq .Values.saleor.django.externalServices.elasticsearch.enabled true }}
+{{- if eq .Values.saleor.django.externalServices.elasticsearch.tls true }}
   - name: ELASTICSEARCH_URL
     value: "https://$(ELASTICSEARCH_USER):$(ELASTICSEARCH_PASSWORD)@$(ELASTICSEARCH_HOST):$(ELASTICSEARCH_PORT)"
 {{- else }}

--- a/deployment/helm/templates/env.yaml
+++ b/deployment/helm/templates/env.yaml
@@ -144,7 +144,7 @@ data:
 {{- if eq .Values.elasticsearch.enabled true }}
   ELASTICSEARCH_HOST: "{{ .Release.Name }}-elasticsearch-client"
   ELASTICSEARCH_PORT: "9200"
-{{- else if .Values.saleor.django.externalServices.elasticsearch.enabled true }}
+{{- else if eq .Values.saleor.django.externalServices.elasticsearch.enabled true }}
   ELASTICSEARCH_USER: {{ .Values.saleor.django.externalServices.elasticsearch.users | quote }}
   ELASTICSEARCH_HOST: {{ .Values.saleor.django.externalServices.elasticsearch.host | quote }}
   ELASTICSEARCH_PORT: {{ .Values.saleor.django.externalServices.elasticsearch.port | quote }}
@@ -173,8 +173,8 @@ data:
 
 {{- if eq .Values.elasticsearch.enabled true }}
   ELASTICSEARCH_URL: "http://$(ELASTICSEARCH_HOST):$(ELASTICSEARCH_PORT)"
-{{- else if .Values.saleor.django.externalServices.elasticsearch.enabled true }}
-{{- if .Values.saleor.django.externalServices.elasticsearch.tls true }}
+{{- else if eq .Values.saleor.django.externalServices.elasticsearch.enabled true }}
+{{- if eq .Values.saleor.django.externalServices.elasticsearch.tls true }}
   ELASTICSEARCH_URL: "https://$(ELASTICSEARCH_USER):$(ELASTICSEARCH_PASSWORD)@$(ELASTICSEARCH_HOST):$(ELASTICSEARCH_PORT)"
 {{- else }}
   ELASTICSEARCH_URL: "http://$(ELASTICSEARCH_USER):$(ELASTICSEARCH_PASSWORD)@$(ELASTICSEARCH_HOST):$(ELASTICSEARCH_PORT)"


### PR DESCRIPTION
Adds the `eq` function to the comparisons that allow elasticsearch not to be deployed.

This *should* make it possible to deploy saleor without elasticsearch.