### PR TITLE
Disable elasticsearch by default

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -62,6 +62,30 @@ Features are describe in more depth on the [saleor README](https://github.com/mi
 - Persistent volumes available with a storageclass
 - Sufficient cpu and memory resources for postgresql, redis, elasticsearch, sentry and saleor
 
+*Note:*
+
+- An elasticsearch cluster requires substantial memory resources, it should not be enabled
+ unless the cluster has sufficient resources.
+
+```text
+elasticsearch:
+  enabled: false
+```
+
+- The elasticsearch deployment can delay the total startup time, 
+it may be necessary to increase the helm timeout if elasticsearch is enabled. 
+
+```
+helm install --timeout 900 ... 
+```
+
+- The sentry deployment takes a several minutes for migrations to complete, 
+increase the helm timeout if sentry is enabled.
+
+```
+helm install --timeout 900 ... 
+```
+
 ## Quickstart
 <div>
   <a style="font-size: 400%;" href="#table-of-contents"> ^ top </a>

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -673,7 +673,7 @@ postgresql:
 ### Corresponds to helm/charts/stable/elasticsearch chart.yaml v1.11.1
 ### Refer to https://github.com/helm/charts/blob/master/stable/elasticsearch/values.yaml
 elasticsearch:
-  enabled: true
+  enabled: false
 
   # Default values for elasticsearch.
   # This is a YAML-formatted file.


### PR DESCRIPTION
What does this commit/MR/PR do?

- Disable elasticsearch by default
- Document the delay in startup time incurred by sentry and
elasticsearch

Why is this commit/MR/PR needed?

- Enhanced documentation, faster startup times
